### PR TITLE
al-support-26-27-drop-24

### DIFF
--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -2,8 +2,6 @@ name: Continuous Integration
 
 on:
   - push
-  - pull_request
-  - workflow_dispatch
 
 jobs:
   ci:

--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:
-        otp: ['24', '25']
+        otp: ['25', '26', '27']
         rebar3: ['3']
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full changelog**: https://github.com/eproxus/grid/compare/v0.2.1...HEAD
 
+### Added
+
+- Official support for Erlang 26 and 27
+
+### Breaking
+
+- Official support for Erlang 24 has been dropped
+
 ## 0.2.1 - 2022-12-07
 
 ### Changed


### PR DESCRIPTION
This pull request introduces a breaking change by dropping support for version 24 which is not supported by Erlang/OTP anymore, while adding support for Erlang versions 26 and 27.

The key changes included in this PR are:

- Removed support for Erlang 24
- Added support for Erlang 26 and 27

This change may require users to upgrade their Erlang installations to version 25 or later in order to continue using the application.